### PR TITLE
Dpc refel coord fix

### DIFF
--- a/FIAT/discontinuous_pc.py
+++ b/FIAT/discontinuous_pc.py
@@ -1,3 +1,5 @@
+# Copyright (C) 2018 Cyrus Cheng (Imperial College London)
+#
 # This file is part of FIAT.
 #
 # FIAT is free software: you can redistribute it and/or modify
@@ -12,8 +14,11 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with FIAT. If not, see <http://www.gnu.org/licenses/>.
+#
+# Modified by David A. Ham (david.ham@imperial.ac.uk), 2018
 
 from FIAT import finite_element, polynomial_set, dual_set, functional
+from FIAT.P0 import P0Dual
 from FIAT.reference_element import (Point,
                                     DefaultLine,
                                     UFCInterval,
@@ -22,7 +27,6 @@ from FIAT.reference_element import (Point,
                                     UFCTriangle,
                                     UFCTetrahedron,
                                     make_affine_mapping)
-from FIAT.P0 import P0Dual
 import numpy as np
 
 hypercube_simplex_map = {Point(): Point(),
@@ -61,14 +65,14 @@ class DPCDualSet(dual_set.DualSet):
         # Vertices of the reference element.
         v_hypercube = ref_el.get_vertices()
         # For the mapping, first two vertices are unchanged in all dimensions.
-        v_ = list(v_hypercube[:2])
+        v_ = [v_hypercube[0], v_hypercube[int(-0.5*len(v_hypercube))]]
 
         # For dimension 1 upwards,
         # take the next vertex and map it to the midpoint of the edge/face it belongs to, and shares
         # with no other points.
         for d in range(1, ref_el.get_dimension()):
-            v_.append(tuple(np.asarray(v_hypercube[d+1] +
-                            np.average(np.asarray(v_hypercube[2**d:2**(d+1)]), axis=0))))
+            v_.append(tuple(np.asarray(v_hypercube[ref_el.get_dimension() - d] +
+                            np.average(np.asarray(v_hypercube[::2]), axis=0))))
         A, b = make_affine_mapping(v_simplex, tuple(v_))  # Make affine mapping to be used later.
 
         # make nodes by getting points
@@ -91,7 +95,7 @@ class DPCDualSet(dual_set.DualSet):
                 entity_ids[dim][entity] = []
 
         entity_ids[dim][0] = list(range(len(nodes)))
-        super(DPCDualSet, self).__init__(nodes, hypercube_simplex_map[ref_el], entity_ids)
+        super(DPCDualSet, self).__init__(nodes, ref_el, entity_ids)
 
 
 class HigherOrderDPC(finite_element.CiarletElement):

--- a/FIAT/dual_set.py
+++ b/FIAT/dual_set.py
@@ -16,9 +16,6 @@
 # along with FIAT. If not, see <http://www.gnu.org/licenses/>.
 
 import numpy
-import collections
-
-from FIAT import polynomial_set
 
 
 class DualSet(object):
@@ -53,79 +50,17 @@ class DualSet(object):
         return self.ref_el
 
     def to_riesz(self, poly_set):
-        """This method gives the action of the entire dual set
-        on each member of the expansion set underlying poly_set.
-        Then, applying the linear functionals of the dual set to an
-        arbitrary polynomial in poly_set is accomplished by matrix
-        multiplication."""
-
-        # This rather technical code queries the low-level information
-        # for each functional to find out where it evaluates its
-        # inputs and/or their derivatives.  Then, it tabulates the
-        # expansion set one time for all the function values and
-        # another for all of the derivatives.  This circumvents
-        # needing to call the to_riesz method of each functional and
-        # also limits the number of different calls to tabulate.
 
         tshape = self.nodes[0].target_shape
         num_nodes = len(self.nodes)
         es = poly_set.get_expansion_set()
-        ed = poly_set.get_embedded_degree()
         num_exp = es.get_num_members(poly_set.get_embedded_degree())
 
         riesz_shape = tuple([num_nodes] + list(tshape) + [num_exp])
 
-        result = numpy.zeros(riesz_shape, "d")
+        self.mat = numpy.zeros(riesz_shape, "d")
 
-        # let's amalgamate the pt_dict and deriv_dicts of all the
-        # functionals so we can tabulate the basis functions twice only
-        # (once on pts and once on derivatives)
+        for i in range(len(self.nodes)):
+            self.mat[i][:] = self.nodes[i].to_riesz(poly_set)
 
-        # Need: dictionary mapping pts to which functionals they come from
-        pts_to_ells = collections.OrderedDict()
-        dpts_to_ells = collections.OrderedDict()
-
-        for i, ell in enumerate(self.nodes):
-            for pt in ell.pt_dict:
-                pts_to_ells.setdefault(pt, []).append(i)
-
-        for i, ell in enumerate(self.nodes):
-            for pt in ell.deriv_dict:
-                dpts_to_ells.setdefault(pt, []).append(i)
-
-        # Now tabulate
-        pts = list(pts_to_ells.keys())
-        expansion_values = es.tabulate(ed, pts)
-
-        for j, pt in enumerate(pts):
-            which_ells = pts_to_ells[pt]
-
-            for k in which_ells:
-                pt_dict = self.nodes[k].pt_dict
-                wc_list = pt_dict[pt]
-
-                for i in range(num_exp):
-                    for (w, c) in wc_list:
-                        result[k][c][i] += w*expansion_values[i, j]
-
-        max_deriv_order = max([ell.max_deriv_order for ell in self.nodes])
-        if max_deriv_order > 0:
-            dpts = list(dpts_to_ells.keys())
-            # It's easiest/most efficient to get derivatives of the
-            # expansion set through the polynomial set interface.
-            # This is creating a short-lived set to do just this.
-            expansion = polynomial_set.ONPolynomialSet(self.ref_el, ed)
-            dexpansion_values = expansion.tabulate(dpts, max_deriv_order)
-
-            for j, pt in enumerate(dpts):
-                which_ells = dpts_to_ells[pt]
-
-                for k in which_ells:
-                    dpt_dict = self.nodes[k].deriv_dict
-                    wac_list = dpt_dict[pt]
-
-                    for i in range(num_exp):
-                        for (w, alpha, c) in wac_list:
-                            result[k][c][i] += w*dexpansion_values[alpha][i, j]
-
-        return result
+        return self.mat

--- a/FIAT/nedelec_second_kind.py
+++ b/FIAT/nedelec_second_kind.py
@@ -29,7 +29,7 @@ from FIAT.reference_element import UFCTetrahedron
 
 
 class NedelecSecondKindDual(DualSet):
-    """
+    r"""
     This class represents the dual basis for the Nedelec H(curl)
     elements of the second kind. The degrees of freedom (L) for the
     elements of the k'th degree are

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -6,9 +6,9 @@ pipelines:
         script:
           - apt-get update
           - apt-get install -y
-              git python3-minimal python3-pip python3-setuptools python3-wheel
+              git python3-minimal python3-pip python3-pytest python3-setuptools python3-wheel
               --no-install-recommends
-          - pip3 install flake8 pytest --upgrade
+          - pip3 install flake8
           - pip3 install .
           - python3 -m flake8
           - DATA_REPO_GIT="" python3 -m pytest -v test/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
-ignore = E501,E226,E731
+ignore = E501,E226,E731,W504
 exclude = .git,__pycache__,doc/sphinx/source/conf.py,build,dist
 min-version = 3.0

--- a/test/regression/test_regression.py
+++ b/test/regression/test_regression.py
@@ -277,7 +277,7 @@ def test_quadrature():
         reference = json.load(open(filename, "r"), object_hook=json_numpy_obj_hook)
         for test_case in test_cases:
             family, dim, degree = test_case
-            _perform_test(family, dim, degree, reference[str(test_case)])
+            yield _perform_test, family, dim, degree, reference[str(test_case)]
 
     # Update references if missing
     except (IOError, KeyError) as e:

--- a/test/unit/test_fiat.py
+++ b/test/unit/test_fiat.py
@@ -203,42 +203,42 @@ elements = [
 
     # MixedElement made of nodal elements should be nodal, but its API
     # is currently just broken.
-    pytest.param("MixedElement(["
-                 "    DiscontinuousLagrange(T, 1),"
-                 "    RaviartThomas(T, 2)"
-                 "])", marks=xfail_impl),
+    xfail_impl("MixedElement(["
+               "    DiscontinuousLagrange(T, 1),"
+               "    RaviartThomas(T, 2)"
+               "])"),
 
     # Following element do not bother implementing get_nodal_basis
     # so the test would need to be rewritten using tabulate
-    pytest.param("TensorProductElement(DiscontinuousLagrange(I, 1), Lagrange(I, 2))", marks=xfail_impl),
-    pytest.param("Hdiv(TensorProductElement(DiscontinuousLagrange(I, 1), Lagrange(I, 2)))", marks=xfail_impl),
-    pytest.param("Hcurl(TensorProductElement(DiscontinuousLagrange(I, 1), Lagrange(I, 2)))", marks=xfail_impl),
-    pytest.param("HDivTrace(T, 1)", marks=xfail_impl),
-    pytest.param("EnrichedElement("
-                 "Hdiv(TensorProductElement(Lagrange(I, 1), DiscontinuousLagrange(I, 0))), "
-                 "Hdiv(TensorProductElement(DiscontinuousLagrange(I, 0), Lagrange(I, 1)))"
-                 ")", marks=xfail_impl),
-    pytest.param("EnrichedElement("
-                 "Hcurl(TensorProductElement(Lagrange(I, 1), DiscontinuousLagrange(I, 0))), "
-                 "Hcurl(TensorProductElement(DiscontinuousLagrange(I, 0), Lagrange(I, 1)))"
-                 ")", marks=xfail_impl),
+    xfail_impl("TensorProductElement(DiscontinuousLagrange(I, 1), Lagrange(I, 2))"),
+    xfail_impl("Hdiv(TensorProductElement(DiscontinuousLagrange(I, 1), Lagrange(I, 2)))"),
+    xfail_impl("Hcurl(TensorProductElement(DiscontinuousLagrange(I, 1), Lagrange(I, 2)))"),
+    xfail_impl("HDivTrace(T, 1)"),
+    xfail_impl("EnrichedElement("
+               "Hdiv(TensorProductElement(Lagrange(I, 1), DiscontinuousLagrange(I, 0))), "
+               "Hdiv(TensorProductElement(DiscontinuousLagrange(I, 0), Lagrange(I, 1)))"
+               ")"),
+    xfail_impl("EnrichedElement("
+               "Hcurl(TensorProductElement(Lagrange(I, 1), DiscontinuousLagrange(I, 0))), "
+               "Hcurl(TensorProductElement(DiscontinuousLagrange(I, 0), Lagrange(I, 1)))"
+               ")"),
     # Following elements are checked using tabulate
-    pytest.param("HDivTrace(T, 0)", marks=xfail_impl),
-    pytest.param("HDivTrace(T, 1)", marks=xfail_impl),
-    pytest.param("HDivTrace(T, 2)", marks=xfail_impl),
-    pytest.param("HDivTrace(T, 3)", marks=xfail_impl),
-    pytest.param("HDivTrace(S, 0)", marks=xfail_impl),
-    pytest.param("HDivTrace(S, 1)", marks=xfail_impl),
-    pytest.param("HDivTrace(S, 2)", marks=xfail_impl),
-    pytest.param("HDivTrace(S, 3)", marks=xfail_impl),
-    pytest.param("TensorProductElement(Lagrange(I, 1), Lagrange(I, 1))", marks=xfail_impl),
-    pytest.param("TensorProductElement(Lagrange(I, 2), Lagrange(I, 2))", marks=xfail_impl),
-    pytest.param("TensorProductElement(TensorProductElement(Lagrange(I, 1), Lagrange(I, 1)), Lagrange(I, 1))", marks=xfail_impl),
-    pytest.param("TensorProductElement(TensorProductElement(Lagrange(I, 2), Lagrange(I, 2)), Lagrange(I, 2))", marks=xfail_impl),
-    pytest.param("FlattenedDimensions(TensorProductElement(Lagrange(I, 1), Lagrange(I, 1)))", marks=xfail_impl),
-    pytest.param("FlattenedDimensions(TensorProductElement(Lagrange(I, 2), Lagrange(I, 2)))", marks=xfail_impl),
-    pytest.param("FlattenedDimensions(TensorProductElement(FlattenedDimensions(TensorProductElement(Lagrange(I, 1), Lagrange(I, 1))), Lagrange(I, 1)))", marks=xfail_impl),
-    pytest.param("FlattenedDimensions(TensorProductElement(FlattenedDimensions(TensorProductElement(Lagrange(I, 2), Lagrange(I, 2))), Lagrange(I, 2)))", marks=xfail_impl),
+    xfail_impl("HDivTrace(T, 0)"),
+    xfail_impl("HDivTrace(T, 1)"),
+    xfail_impl("HDivTrace(T, 2)"),
+    xfail_impl("HDivTrace(T, 3)"),
+    xfail_impl("HDivTrace(S, 0)"),
+    xfail_impl("HDivTrace(S, 1)"),
+    xfail_impl("HDivTrace(S, 2)"),
+    xfail_impl("HDivTrace(S, 3)"),
+    xfail_impl("TensorProductElement(Lagrange(I, 1), Lagrange(I, 1))"),
+    xfail_impl("TensorProductElement(Lagrange(I, 2), Lagrange(I, 2))"),
+    xfail_impl("TensorProductElement(TensorProductElement(Lagrange(I, 1), Lagrange(I, 1)), Lagrange(I, 1))"),
+    xfail_impl("TensorProductElement(TensorProductElement(Lagrange(I, 2), Lagrange(I, 2)), Lagrange(I, 2))"),
+    xfail_impl("FlattenedDimensions(TensorProductElement(Lagrange(I, 1), Lagrange(I, 1)))"),
+    xfail_impl("FlattenedDimensions(TensorProductElement(Lagrange(I, 2), Lagrange(I, 2)))"),
+    xfail_impl("FlattenedDimensions(TensorProductElement(FlattenedDimensions(TensorProductElement(Lagrange(I, 1), Lagrange(I, 1))), Lagrange(I, 1)))"),
+    xfail_impl("FlattenedDimensions(TensorProductElement(FlattenedDimensions(TensorProductElement(Lagrange(I, 2), Lagrange(I, 2))), Lagrange(I, 2)))"),
 ]
 
 

--- a/test/unit/test_quadrature.py
+++ b/test/unit/test_quadrature.py
@@ -134,39 +134,21 @@ def test_create_quadrature_extr_quadrilateral(extr_quadrilateral, basedeg, extrd
                           (2**(basedeg + 2) - 2) / ((basedeg + 1)*(basedeg + 2)) * 1/(extrdeg + 1))
 
 
-def test_invalid_quadrature_degree_interval(interval, scheme):
+@pytest.mark.parametrize("cell", [interval(),
+                                  triangle(),
+                                  tetrahedron(),
+                                  quadrilateral()])
+def test_invalid_quadrature_degree(cell, scheme):
     with pytest.raises(ValueError):
-        FIAT.create_quadrature(interval, -1, scheme)
+        FIAT.create_quadrature(cell, -1, scheme)
 
 
-def test_invalid_quadrature_degree_tri(triangle, scheme):
+@pytest.mark.parametrize("cell", [extr_interval(),
+                                  extr_triangle(),
+                                  extr_quadrilateral()])
+def test_invalid_quadrature_degree_tensor_prod(cell):
     with pytest.raises(ValueError):
-        FIAT.create_quadrature(triangle, -1, scheme)
-
-
-def test_invalid_quadrature_degree_quad(quadrilateral, scheme):
-    with pytest.raises(ValueError):
-        FIAT.create_quadrature(quadrilateral, -1, scheme)
-
-
-def test_invalid_quadrature_degree_tet(tetrahedron, scheme):
-    with pytest.raises(ValueError):
-        FIAT.create_quadrature(tetrahedron, -1, scheme)
-
-
-def test_invalid_quadrature_degree_tensor_prod_interval(extr_interval):
-    with pytest.raises(ValueError):
-        FIAT.create_quadrature(extr_interval, (-1, -1))
-
-
-def test_invalid_quadrature_degree_tensor_prod_tri(extr_triangle):
-    with pytest.raises(ValueError):
-        FIAT.create_quadrature(extr_triangle, (-1, -1))
-
-
-def test_invalid_quadrature_degree_tensor_prod_quad(extr_quadrilateral):
-    with pytest.raises(ValueError):
-        FIAT.create_quadrature(extr_quadrilateral, (-1, -1))
+        FIAT.create_quadrature(cell, (-1, -1))
 
 
 def test_tensor_product_composition(interval, triangle, extr_triangle, scheme):

--- a/test/unit/test_reference_element.py
+++ b/test/unit/test_reference_element.py
@@ -39,8 +39,8 @@ ufc_hexahedron_21connectivity = [(0, 1, 4, 5), (2, 3, 6, 7), (0, 2, 8, 9),
 @pytest.mark.parametrize(('cell', 'connectivity'),
                          [(tetrahedron, ufc_tetrahedron_21connectivity),
                           (hexahedron, ufc_hexahedron_21connectivity),
-                          pytest.param(triangle_x_interval, [], marks=pytest.mark.xfail),
-                          pytest.param(quadrilateral_x_interval, [], marks=pytest.mark.xfail)])
+                          pytest.mark.xfail((triangle_x_interval, [])),
+                          pytest.mark.xfail((quadrilateral_x_interval, []))])
 def test_ufc_connectivity_21(cell, connectivity):
     """Check face-edge connectivity builds what UFC expects.
     This is only non-trivial case ; the rest is x-0 and D-x,
@@ -51,9 +51,9 @@ def test_ufc_connectivity_21(cell, connectivity):
 @pytest.mark.parametrize('cell',
                          [point, interval, triangle, tetrahedron,
                           quadrilateral, hexahedron,
-                          pytest.param(interval_x_interval, marks=pytest.mark.xfail),
-                          pytest.param(triangle_x_interval, marks=pytest.mark.xfail),
-                          pytest.param(quadrilateral_x_interval, marks=pytest.mark.xfail)])
+                          pytest.mark.xfail(interval_x_interval),
+                          pytest.mark.xfail(triangle_x_interval),
+                          pytest.mark.xfail(quadrilateral_x_interval)])
 def test_ufc_connectivity_x0(cell):
     """Check x-0 connectivity is just what get_topology gives"""
     for dim0 in range(cell.get_spatial_dimension()+1):
@@ -66,9 +66,9 @@ def test_ufc_connectivity_x0(cell):
 @pytest.mark.parametrize('cell',
                          [point, interval, triangle, tetrahedron,
                           quadrilateral, hexahedron,
-                          pytest.param(interval_x_interval, marks=pytest.mark.xfail),
-                          pytest.param(triangle_x_interval, marks=pytest.mark.xfail),
-                          pytest.param(quadrilateral_x_interval, marks=pytest.mark.xfail)])
+                          pytest.mark.xfail(interval_x_interval),
+                          pytest.mark.xfail(triangle_x_interval),
+                          pytest.mark.xfail(quadrilateral_x_interval)])
 def test_ufc_connectivity_Dx(cell):
     """Check D-x connectivity is just [(0,1,2,...)]"""
     D = cell.get_spatial_dimension()
@@ -79,7 +79,7 @@ def test_ufc_connectivity_Dx(cell):
 
 
 @pytest.mark.parametrize(('cell', 'volume'),
-                         [pytest.param(point, 1, marks=pytest.mark.xfail),
+                         [pytest.mark.xfail((point, 1)),
                           (interval, 1),
                           (triangle, 1/2),
                           (quadrilateral, 1),


### PR DESCRIPTION
-The previous coordinate change mapping stretched out the simplex that the nodes reside on, which is undesirable.
-The reference element was passed to DualSet as a simplex, it is now passed as the original hypercube

These bug fixes are introduced in this pull request.