### PR TITLE
Output NaN for gradient for HDivTrace element

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run:
           name: Install dependencies  # Install with sudo as tests not run as superuser in circleci/python
-          command: sudo pip install flake8 pytest pydocstyle numpy sympy coverage coveralls --upgrade
+          command: sudo pip install flake8 pytest pydocstyle numpy sympy 'coverage<5' coveralls --upgrade
       - run:
           name: Install FIAT
           command: pip install . --user

--- a/FIAT/hdiv_trace.py
+++ b/FIAT/hdiv_trace.py
@@ -201,7 +201,7 @@ class HDivTrace(FiniteElement):
                 # Retrieve values by tabulating the DG element
                 element = self.dg_elements[facet_sd]
                 nf = element.space_dimension()
-                nonzerovals, = element.tabulate(order, new_points).values()
+                nonzerovals, = element.tabulate(0, new_points).values()
                 indices = slice(nf * unique_facet, nf * (unique_facet + 1))
 
         else:
@@ -234,13 +234,12 @@ class HDivTrace(FiniteElement):
 
                         offset += nf
 
-        # If asking for gradient evaluations, insert TraceError in
-        # gradient slots
+        # If asking for gradient evaluations, return NaN
         if order > 0:
-            msg = "Gradients on trace elements are not well-defined."
             for key in phivals:
                 if key != evalkey:
-                    phivals[key] = TraceError(msg)
+                    phivals[key] = np.full(shape=(self.space_dimension(),
+                                                  len(points)), fill_value=np.nan)
 
         # Insert non-zero values in appropriate place
         phivals[evalkey][indices, :] = nonzerovals

--- a/FIAT/hdiv_trace.py
+++ b/FIAT/hdiv_trace.py
@@ -234,12 +234,13 @@ class HDivTrace(FiniteElement):
 
                         offset += nf
 
-        # If asking for gradient evaluations, return NaN
+        # If asking for gradient evaluations, insert TraceError in
+        # gradient slots
         if order > 0:
+            msg = "Gradients on trace elements are not well-defined."
             for key in phivals:
                 if key != evalkey:
-                    phivals[key] = np.full(shape=(self.space_dimension(),
-                                                  len(points)), fill_value=np.nan)
+                    phivals[key] = TraceError(msg)
 
         # Insert non-zero values in appropriate place
         phivals[evalkey][indices, :] = nonzerovals

--- a/test/unit/test_hdivtrace.py
+++ b/test/unit/test_hdivtrace.py
@@ -106,6 +106,7 @@ def test_gradient_traceerror(dim, order, degree):
     """Ensure that the TraceError appears in the appropriate dict entries when
     attempting to tabulate certain orders of derivatives."""
     from FIAT import ufc_simplex, HDivTrace, make_quadrature
+    from FIAT.hdiv_trace import TraceError
 
     fiat_element = HDivTrace(ufc_simplex(dim), degree)
     pts = make_quadrature(ufc_simplex(dim - 1), degree + 1).pts
@@ -115,7 +116,7 @@ def test_gradient_traceerror(dim, order, degree):
 
         for key in tab.keys():
             if key != (0,)*dim:
-                assert np.isnan(tab[key]).all()
+                assert isinstance(tab[key], TraceError)
 
 
 @pytest.mark.parametrize("dim", (2, 3))

--- a/test/unit/test_hdivtrace.py
+++ b/test/unit/test_hdivtrace.py
@@ -106,7 +106,6 @@ def test_gradient_traceerror(dim, order, degree):
     """Ensure that the TraceError appears in the appropriate dict entries when
     attempting to tabulate certain orders of derivatives."""
     from FIAT import ufc_simplex, HDivTrace, make_quadrature
-    from FIAT.hdiv_trace import TraceError
 
     fiat_element = HDivTrace(ufc_simplex(dim), degree)
     pts = make_quadrature(ufc_simplex(dim - 1), degree + 1).pts
@@ -116,7 +115,7 @@ def test_gradient_traceerror(dim, order, degree):
 
         for key in tab.keys():
             if key != (0,)*dim:
-                assert isinstance(tab[key], TraceError)
+                assert np.isnan(tab[key]).all()
 
 
 @pytest.mark.parametrize("dim", (2, 3))


### PR DESCRIPTION
Change the output from `TraceError` to `np.nan` for gradient of HDivT element.
The reason for this change is that `ffc` may generate tables for `MixedElement` containing gradients, even if not needed. See https://github.com/FEniCS/dolfinx/issues/684.