### PR TITLE
Broadcast result of lambdify in Serendipity tabulation

### DIFF
--- a/FIAT/serendipity.py
+++ b/FIAT/serendipity.py
@@ -150,6 +150,8 @@ class Serendipity(FiniteElement):
             raise NotImplementedError('no tabulate method for serendipity elements of dimension 1 or less.')
         if dim >= 4:
             raise NotImplementedError('tabulate does not support higher dimensions than 3.')
+        points = np.asarray(points)
+        npoints, pointdim = points.shape
         for o in range(order + 1):
             alphas = mis(dim, o)
             for alpha in alphas:
@@ -160,8 +162,9 @@ class Serendipity(FiniteElement):
                     callable = lambdify(variables[:dim], polynomials, modules="numpy", dummify=True)
                     self.basis[alpha] = polynomials
                     self.basis_callable[alpha] = callable
-                points = np.asarray(points)
-                T = np.asarray(callable(*(points[:, i] for i in range(points.shape[1]))))
+                tabulation = callable(*(points[:, i] for i in range(pointdim)))
+                T = np.asarray([np.broadcast_to(tab, (npoints, ))
+                                for tab in tabulation])
                 phivals[alpha] = T
         return phivals
 

--- a/test/unit/test_serendipity.py
+++ b/test/unit/test_serendipity.py
@@ -1,0 +1,34 @@
+from FIAT.reference_element import UFCQuadrilateral
+from FIAT import Serendipity
+import numpy as np
+import sympy
+import pytest
+
+
+@pytest.mark.xfail(reason="Higher derivatives drop shape")
+def test_serendipity_derivatives():
+    cell = UFCQuadrilateral()
+    S = Serendipity(cell, 2)
+
+    x = sympy.DeferredVector("X")
+    X, Y = x[0], x[1]
+    basis_functions = [
+        (1 - X)*(1 - Y),
+        Y*(1 - X),
+        X*(1 - Y),
+        X*Y,
+        Y*(1 - X)*(Y - 1),
+        X*Y*(Y - 1),
+        X*(1 - Y)*(X - 1),
+        X*Y*(X - 1),
+    ]
+    points = [[0.5, 0.5], [0.25, 0.75]]
+    for alpha, actual in S.tabulate(2, points).items():
+        expect = list(sympy.diff(basis, *zip([X, Y], alpha))
+                      for basis in basis_functions)
+        expect = list([basis.subs(dict(zip([X, Y], point)))
+                       for point in points]
+                      for basis in expect)
+        assert actual.shape == (8, 2)
+        assert np.allclose(np.asarray(expect, dtype=float),
+                           actual.reshape(8, 2))

--- a/test/unit/test_serendipity.py
+++ b/test/unit/test_serendipity.py
@@ -2,10 +2,8 @@ from FIAT.reference_element import UFCQuadrilateral
 from FIAT import Serendipity
 import numpy as np
 import sympy
-import pytest
 
 
-@pytest.mark.xfail(reason="Higher derivatives drop shape")
 def test_serendipity_derivatives():
     cell = UFCQuadrilateral()
     S = Serendipity(cell, 2)


### PR DESCRIPTION
lambdify doesn't preserve shape when the result is zero. Fixes
firedrakeproject/firedrake#1783.