### PR TITLE
orientations: define entity_permutations for CG and DG elements

### DIFF
--- a/FIAT/P0.py
+++ b/FIAT/P0.py
@@ -18,6 +18,7 @@ class P0Dual(dual_set.DualSet):
     def __init__(self, ref_el):
         entity_ids = {}
         nodes = []
+        entity_permutations = {}
         vs = numpy.array(ref_el.get_vertices())
         if ref_el.get_dimension() == 0:
             bary = ()
@@ -29,12 +30,23 @@ class P0Dual(dual_set.DualSet):
         top = ref_el.get_topology()
         for dim in sorted(top):
             entity_ids[dim] = {}
+            entity_permutations[dim] = {}
+            sym_size = ref_el.symmetry_group_size(dim)
+            if isinstance(dim, tuple):
+                assert isinstance(sym_size, tuple)
+                perms = {o: [] for o in numpy.ndindex(sym_size)}
+            else:
+                perms = {o: [] for o in range(sym_size)}
             for entity in sorted(top[dim]):
                 entity_ids[dim][entity] = []
-
+                entity_permutations[dim][entity] = perms
         entity_ids[dim] = {0: [0]}
+        if isinstance(dim, tuple):
+            entity_permutations[dim][0] = {o: [0, ] for o in numpy.ndindex(sym_size)}
+        else:
+            entity_permutations[dim][0] = {o: [0, ] for o in range(sym_size)}
 
-        super(P0Dual, self).__init__(nodes, ref_el, entity_ids)
+        super(P0Dual, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
 
 
 class P0(finite_element.CiarletElement):

--- a/FIAT/discontinuous_lagrange.py
+++ b/FIAT/discontinuous_lagrange.py
@@ -5,7 +5,60 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+import numpy as np
 from FIAT import finite_element, polynomial_set, dual_set, functional, P0
+from FIAT.finite_element import make_barycentric_lattice_coordinates, make_index_permutations
+
+
+def make_entity_permutations(dim, npoints):
+    if npoints <= 0:
+        return {o: [] for o in range(np.math.factorial(dim + 1))}
+    a = make_barycentric_lattice_coordinates(dim, npoints - 1)
+    index_perms = make_index_permutations(dim + 1)
+    # Make DG nodes CG nodes map
+    #
+    # DG nodes are ordered by:
+    # - group 0: entity dim
+    # - group 1: entity ids
+    # - cg counterpart node numbers (lexicographic)
+    #
+    # Ex: dim = 2, degree = 3
+    #
+    #     facet ids    cg node numbers
+    #    +
+    #    | \              3
+    #    |   \  0         2 6
+    #  2 |     \          1 5 8
+    #    |       \        0 4 7 9
+    #    +--------+
+    #        1
+    #
+    # group0    = [ 0, 1, 1, 0, 1, 2, 1, 1, 1, 0]
+    # group1    = [-3, 2, 2,-2, 1, 0, 0, 1, 0,-1]
+    # cg        = [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    #
+    # dg_cg_map = [ 0, 3, 9, 6, 8, 4, 7, 1, 2, 5]
+    #
+    g0 = dim - (a == 0).astype(int).sum(axis=1)
+    g1 = np.zeros_like(g0)
+    for d in range(dim + 1):
+        on_facet_d = (a[:, d] == 0).astype(int)
+        g1 += d * on_facet_d
+    # Vertices are numbered differently from facets/edges
+    # in FIAT, so we need to reverse.
+    g1[g0 == 0] = -g1[g0 == 0]
+    g0 = g0.reshape((a.shape[0], 1))
+    g1 = g1.reshape((a.shape[0], 1))
+    dg_cg_map = np.lexsort(np.transpose(np.concatenate((a, g1, g0), axis=1)))
+    cg_dg_map = np.empty_like(dg_cg_map)
+    for i, im in enumerate(dg_cg_map):
+        cg_dg_map[im] = i
+    perms = {}
+    for o, index_perm in enumerate(index_perms):
+        perm = np.lexsort(np.transpose(a[:, index_perm]))
+        perm = cg_dg_map[perm][dg_cg_map]
+        perms[o] = perm.tolist()
+    return perms
 
 
 class DiscontinuousLagrangeDualSet(dual_set.DualSet):
@@ -17,6 +70,7 @@ class DiscontinuousLagrangeDualSet(dual_set.DualSet):
     def __init__(self, ref_el, degree):
         entity_ids = {}
         nodes = []
+        entity_permutations = {}
 
         # make nodes by getting points
         # need to do this dimension-by-dimension, facet-by-facet
@@ -25,6 +79,8 @@ class DiscontinuousLagrangeDualSet(dual_set.DualSet):
         cur = 0
         for dim in sorted(top):
             entity_ids[dim] = {}
+            entity_permutations[dim] = {}
+            perms = make_entity_permutations(dim, degree + 1 if dim == len(top) - 1 else -1)
             for entity in sorted(top[dim]):
                 pts_cur = ref_el.make_points(dim, entity, degree)
                 nodes_cur = [functional.PointEvaluation(ref_el, x)
@@ -33,10 +89,10 @@ class DiscontinuousLagrangeDualSet(dual_set.DualSet):
                 nodes += nodes_cur
                 entity_ids[dim][entity] = []
                 cur += nnodes_cur
-
+                entity_permutations[dim][entity] = perms
         entity_ids[dim][0] = list(range(len(nodes)))
 
-        super(DiscontinuousLagrangeDualSet, self).__init__(nodes, ref_el, entity_ids)
+        super(DiscontinuousLagrangeDualSet, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
 
 
 class HigherOrderDiscontinuousLagrange(finite_element.CiarletElement):

--- a/FIAT/dual_set.py
+++ b/FIAT/dual_set.py
@@ -13,10 +13,11 @@ from FIAT import polynomial_set
 
 
 class DualSet(object):
-    def __init__(self, nodes, ref_el, entity_ids):
+    def __init__(self, nodes, ref_el, entity_ids, entity_permutations=None):
         self.nodes = nodes
         self.ref_el = ref_el
         self.entity_ids = entity_ids
+        self.entity_permutations = entity_permutations
 
         # Compute the nodes on the closure of each sub_entity.
         self.entity_closure_ids = {}
@@ -39,6 +40,9 @@ class DualSet(object):
 
     def get_entity_ids(self):
         return self.entity_ids
+
+    def get_entity_permutations(self):
+        return self.entity_permutations
 
     def get_reference_element(self):
         return self.ref_el

--- a/FIAT/gauss_legendre.py
+++ b/FIAT/gauss_legendre.py
@@ -13,6 +13,7 @@ import numpy
 from FIAT import finite_element, polynomial_set, dual_set, functional, quadrature
 from FIAT.reference_element import LINE
 from FIAT.barycentric_interpolation import barycentric_interpolation
+from FIAT.lagrange import make_entity_permutations
 
 
 class GaussLegendreDualSet(dual_set.DualSet):
@@ -23,8 +24,11 @@ class GaussLegendreDualSet(dual_set.DualSet):
                       1: {0: list(range(0, degree+1))}}
         lr = quadrature.GaussLegendreQuadratureLineRule(ref_el, degree+1)
         nodes = [functional.PointEvaluation(ref_el, x) for x in lr.pts]
+        entity_permutations = {}
+        entity_permutations[0] = {0: {0: []}, 1: {0: []}}
+        entity_permutations[1] = {0: make_entity_permutations(1, degree + 1)}
 
-        super(GaussLegendreDualSet, self).__init__(nodes, ref_el, entity_ids)
+        super(GaussLegendreDualSet, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
 
 
 class GaussLegendre(finite_element.CiarletElement):

--- a/FIAT/gauss_lobatto_legendre.py
+++ b/FIAT/gauss_lobatto_legendre.py
@@ -13,6 +13,7 @@ import numpy
 from FIAT import finite_element, polynomial_set, dual_set, functional, quadrature
 from FIAT.reference_element import LINE
 from FIAT.barycentric_interpolation import barycentric_interpolation
+from FIAT.lagrange import make_entity_permutations
 
 
 class GaussLobattoLegendreDualSet(dual_set.DualSet):
@@ -23,8 +24,11 @@ class GaussLobattoLegendreDualSet(dual_set.DualSet):
                       1: {0: list(range(1, degree))}}
         lr = quadrature.GaussLobattoLegendreQuadratureLineRule(ref_el, degree+1)
         nodes = [functional.PointEvaluation(ref_el, x) for x in lr.pts]
+        entity_permutations = {}
+        entity_permutations[0] = {0: {0: [0, ]}, 1: {0: [0, ]}}
+        entity_permutations[1] = {0: make_entity_permutations(1, degree - 1)}
 
-        super(GaussLobattoLegendreDualSet, self).__init__(nodes, ref_el, entity_ids)
+        super(GaussLobattoLegendreDualSet, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
 
 
 class GaussLobattoLegendre(finite_element.CiarletElement):

--- a/FIAT/lagrange.py
+++ b/FIAT/lagrange.py
@@ -6,6 +6,65 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 from FIAT import finite_element, polynomial_set, dual_set, functional
+from FIAT.finite_element import make_barycentric_lattice_coordinates, make_index_permutations
+import numpy as np
+
+
+def make_entity_permutations(dim, npoints):
+    r"""Make orientation-permutation map for the given
+    simplex dimension, dim, and the number of points along
+    each axis
+
+    As an example, we first compute the orientation of a
+    triangular cell:
+
+       +                    +
+       | \                  | \
+       2   0               47   42
+       |     \              |     \
+       +--1---+             +--43--+
+    FIAT canonical     Mapped example physical cell
+
+    Suppose that the cone of the physical cell is given by:
+
+    C = [47, 42, 43]
+
+    FIAT facet to Physical facet map is given by:
+
+    M = [42, 43, 47]
+
+    Then the orientation of the cell is computed as:
+
+    C.index(M[0]) = 1; C.remove(M[0])
+    C.index(M[1]) = 1; C.remove(M[1])
+    C.index(M[2]) = 0; C.remove(M[2])
+
+    o = (1 * 2!) + (1 * 1!) + (0 * 0!) = 3
+
+    For npoints = 3, there are 6 DoFs:
+
+        2                   5
+        1 4                 4 3
+        0 3 5               2 1 0
+    FIAT canonical     Physical cell canonical
+
+    The permutation associated with o = 3 then is:
+
+    [2, 4, 5, 1, 3, 0]
+
+    The output of this function contains one such permutation
+    for each orientation for the given simplex dimension and
+    the number of points along each axis.
+    """
+    if npoints <= 0:
+        return {o: [] for o in range(np.math.factorial(dim + 1))}
+    a = make_barycentric_lattice_coordinates(dim, npoints - 1)
+    index_perms = make_index_permutations(dim + 1)
+    perms = {}
+    for o, index_perm in enumerate(index_perms):
+        perm = np.lexsort(np.transpose(a[:, index_perm]))
+        perms[o] = perm.tolist()
+    return perms
 
 
 class LagrangeDualSet(dual_set.DualSet):
@@ -16,6 +75,7 @@ class LagrangeDualSet(dual_set.DualSet):
     def __init__(self, ref_el, degree):
         entity_ids = {}
         nodes = []
+        entity_permutations = {}
 
         # make nodes by getting points
         # need to do this dimension-by-dimension, facet-by-facet
@@ -24,6 +84,8 @@ class LagrangeDualSet(dual_set.DualSet):
         cur = 0
         for dim in sorted(top):
             entity_ids[dim] = {}
+            entity_permutations[dim] = {}
+            perms = {0: [0, ]} if dim == 0 else make_entity_permutations(dim, degree - dim)
             for entity in sorted(top[dim]):
                 pts_cur = ref_el.make_points(dim, entity, degree)
                 nodes_cur = [functional.PointEvaluation(ref_el, x)
@@ -32,8 +94,9 @@ class LagrangeDualSet(dual_set.DualSet):
                 nodes += nodes_cur
                 entity_ids[dim][entity] = list(range(cur, cur + nnodes_cur))
                 cur += nnodes_cur
+                entity_permutations[dim][entity] = perms
 
-        super(LagrangeDualSet, self).__init__(nodes, ref_el, entity_ids)
+        super(LagrangeDualSet, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
 
 
 class Lagrange(finite_element.CiarletElement):


### PR DESCRIPTION
This PR is to attach `entity_permutations` `dict` to basic finite elements (such as `Lagrange`) that defines a DoF permutation (to be used in global vector assembly) for each possible entity orientation for each entity for each dimension. 
`entity_permutations` is set `None` if it is not yet implemented for that element, so the problem solving environment must handle this correctly if it ever tries to access this attribute.

This is intended to be the first step for FIAT to handle orientations.